### PR TITLE
Removing long string from cat

### DIFF
--- a/megalut/meas/galsim_adamom.py
+++ b/megalut/meas/galsim_adamom.py
@@ -82,9 +82,11 @@ def measure(bigimg, catalog, xname="x", yname="y", stampsize=100, prefix="mes_ad
 	#astropy.table.MaskedColumn(name="mes_adamom_flux", dtype=float, length=len(output), fill_value=-1)
 	
 	# Let's save something useful to the meta dict
-	output.meta[prefix + "_imgfilepath"] = bigimg.origimgfilepath
 	output.meta[prefix + "_xname"] = xname
 	output.meta[prefix + "_yname"] = yname
+	
+	# We do not store this long string here, as it leads to problems when saving the cat to FITS
+	#output.meta[prefix + "_imgfilepath"] = bigimg.origimgfilepath
 	
 	n = len(output)
 	


### PR DESCRIPTION
A tiny change.
In principle, we should _not_ avoid storing long strings in our catalogs just because this leads to issues when saving to FITS. But in this case, storing this string was just an experiment, so I remove it for now to avoid hassle.
