### PR TITLE
plot: Removing default mec:None for plot()

### DIFF
--- a/megalut/plot/scatter.py
+++ b/megalut/plot/scatter.py
@@ -78,7 +78,7 @@ def scatter(ax, cat, featx, featy, featc=None, cmap="jet", title=None, showid=Fa
 	else: # We will use plot()
 	
 		logger.debug("Preparing plain plot of %i points without colorbar" % (len(cat)))
-		mykwargs = {"marker":".", "ms":5, "color":"black", "ls":"None", "mec":"None", "alpha":0.3}
+		mykwargs = {"marker":".", "ms":5, "color":"black", "ls":"None", "alpha":0.3}
 	
 		# We overwrite these mykwargs with any user-specified kwargs:
 		mykwargs.update(kwargs)


### PR DESCRIPTION
This made points disappear in the latest version of matplotlib.
It is not needed anyway and was there by error. 
I tested that the updated code still works with the previous matplotlib.

(#29)
If you don't object, I'll merge this in very soon...
